### PR TITLE
feat: Implement core prompt management features and enhance search

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,163 +1,314 @@
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, Text, View, TextInput, ScrollView, Button, TouchableOpacity, Platform } from 'react-native';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  SafeAreaView,
+  StyleSheet,
+  View,
+  TextInput,
+  Button,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+  ActivityIndicator,
+  Platform,
+} from 'react-native';
 
-const API_BASE = Platform.OS === 'android' ? 'http://10.0.2.2:3000' : 'http://localhost:3000';
+const API_BASE = 'http://localhost:3000'; // Ensure this is your actual API base URL
 
-export default function App() {
+const App = () => {
   const [prompts, setPrompts] = useState([]);
-  const [search, setSearch] = useState('');
-  const [text, setText] = useState('');
-  const [tool, setTool] = useState('');
-  const [tags, setTags] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchTags, setSearchTags] = useState(''); // New state for tag search input
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
 
-  async function load() {
-    const res = await fetch(`${API_BASE}/api/prompts/search?q=${encodeURIComponent(search)}`);
-    const data = await res.json();
-    setPrompts(data);
-  }
+  const [formVisible, setFormVisible] = useState(false);
+  const [newPromptText, setNewPromptText] = useState('');
+  const [newPromptTool, setNewPromptTool] = useState('');
+  const [newPromptTags, setNewPromptTags] = useState(''); // For adding/editing prompt tags
 
-  async function addPrompt() {
-    await fetch(`${API_BASE}/api/prompts`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        text,
-        tool,
-        tags: tags.split(',').map(t => t.trim()).filter(Boolean)
-      })
-    });
-    setText('');
-    setTool('');
-    setTags('');
-    load();
-  }
+  const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
+  const [editingPrompt, setEditingPrompt] = useState(null);
 
-  useEffect(() => {
-    load();
+  const scrollViewRef = useRef(null);
+
+  const fetchPrompts = useCallback(async (keywordQuery = '', tagsQuery = '') => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      let queryString = `q=${encodeURIComponent(keywordQuery)}`;
+      if (tagsQuery.trim() !== '') {
+        queryString += `&tag=${encodeURIComponent(tagsQuery)}`;
+      }
+
+      const response = await fetch(`${API_BASE}/api/prompts/search?${queryString}`);
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ message: `HTTP error! status: ${response.status}` }));
+        throw new Error(errData.message);
+      }
+      const data = await response.json();
+      setPrompts(data);
+    } catch (e) {
+      setError(e.message);
+      Alert.alert("Error", "Failed to fetch prompts: " + e.message);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
+  // useEffect to fetch prompts when searchQuery or searchTags change
+  useEffect(() => {
+    // Debounce or delay could be added here if desired, for now, it fetches on each change
+    fetchPrompts(searchQuery, searchTags);
+  }, [fetchPrompts, searchQuery, searchTags]);
+
+  const handleSubmitPrompt = async () => {
+    if (!newPromptText.trim()) {
+      Alert.alert("Validation", "Prompt text cannot be empty.");
+      return;
+    }
+    setIsLoading(true);
+    const tagsArray = newPromptTags.split(',').map(tag => tag.trim()).filter(tag => tag);
+    const url = editingPrompt 
+      ? `${API_BASE}/api/prompts/${editingPrompt.id}` 
+      : `${API_BASE}/api/prompts`;
+    const method = editingPrompt ? 'PUT' : 'POST';
+    const body = editingPrompt 
+      ? { text: newPromptText, tool: newPromptTool, tags: tagsArray, favorite: editingPrompt.favorite }
+      : { text: newPromptText, tool: newPromptTool, tags: tagsArray, favorite: false };
+
+    try {
+      const response = await fetch(url, {
+        method: method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ message: 'Unknown API error' }));
+        throw new Error(errData.message || `HTTP error! status: ${response.status}`);
+      }
+      const updatedOrNewPrompt = await response.json();
+      if (editingPrompt) {
+        setPrompts(prevPrompts =>
+          prevPrompts.map(p => (p.id === editingPrompt.id ? updatedOrNewPrompt : p))
+        );
+      } else {
+        // Refresh with current search terms after adding
+        fetchPrompts(searchQuery, searchTags); 
+      }
+      setNewPromptText('');
+      setNewPromptTool('');
+      setNewPromptTags('');
+      setEditingPrompt(null);
+      setFormVisible(false);
+    } catch (e) {
+      setError(e.message);
+      Alert.alert("Error", `Failed to ${editingPrompt ? 'update' : 'add'} prompt: ${e.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const toggleFavorite = async (id, currentFavoriteStatus) => {
+    try {
+      const response = await fetch(`${API_BASE}/api/prompts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ favorite: !currentFavoriteStatus }),
+      });
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ message: 'Unknown API error' }));
+        throw new Error(errData.message || `HTTP error! status: ${response.status}`);
+      }
+      const updatedPrompt = await response.json();
+      setPrompts(prevPrompts =>
+        prevPrompts.map(p => (p.id === id ? updatedPrompt : p))
+      );
+    } catch (e) {
+      Alert.alert("Error", `Failed to update favorite status: ${e.message}`);
+    }
+  };
+
+  const handleStartEdit = (prompt) => {
+    setEditingPrompt(prompt);
+    setNewPromptText(prompt.text);
+    setNewPromptTool(prompt.tool);
+    setNewPromptTags(prompt.tags.join(', '));
+    setFormVisible(true);
+    setTimeout(() => scrollViewRef.current?.scrollTo({ y: 0, animated: true }), 100);
+  };
+
+  const handleCancelForm = () => {
+    setEditingPrompt(null);
+    setNewPromptText('');
+    setNewPromptTool('');
+    setNewPromptTags('');
+    setFormVisible(false);
+  };
+
+  const handleDeletePrompt = (promptId) => {
+    Alert.alert(
+      "Delete Prompt",
+      "Are you sure you want to delete this prompt?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            setIsLoading(true);
+            try {
+              const response = await fetch(`${API_BASE}/api/prompts/${promptId}`, {
+                method: 'DELETE',
+              });
+              if (!response.ok) {
+                const errData = await response.json().catch(() => ({ message: 'Unknown API error during delete' }));
+                throw new Error(errData.message || `HTTP error! status: ${response.status}`);
+              }
+              setPrompts(prevPrompts => prevPrompts.filter(p => p.id !== promptId));
+            } catch (e) {
+              Alert.alert("Error", `Failed to delete prompt: ${e.message}`);
+            } finally {
+              setIsLoading(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+  
+  // Client-side filtering for favorites, applied to the API results
+  const displayedPrompts = showOnlyFavorites
+    ? prompts.filter(p => p.favorite)
+    : prompts;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>PromptCache</Text>
-      <View style={styles.searchRow}>
-        <TextInput
-          style={styles.input}
-          placeholder="Search prompts"
-          placeholderTextColor="#888"
-          value={search}
-          onChangeText={setSearch}
-        />
-        <Button title="Search" onPress={load} />
-      </View>
-      <ScrollView style={styles.list}>
-        {prompts.map(p => (
-          <View key={p.id} style={styles.prompt}>
-            <View style={styles.promptHeader}>
-              <Text style={styles.tool}>{p.tool}</Text>
-              <Text style={styles.tags}>{p.tags.join(', ')}</Text>
-            </View>
-            <Text style={styles.text}>{p.text}</Text>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView ref={scrollViewRef} style={styles.containerScrollView} keyboardShouldPersistTaps="handled">
+        <View style={styles.container}>
+          <Text style={styles.header}>PromptCache Mobile</Text>
+
+          <TextInput
+            style={styles.searchInput}
+            placeholder="Search by keyword..."
+            value={searchQuery}
+            onChangeText={setSearchQuery} // Triggers fetchPrompts via useEffect
+          />
+          {/* New TextInput for tags */}
+          <TextInput
+            style={styles.searchInput} // Reusing similar style
+            placeholder="Filter by tags (e.g., js,react)"
+            value={searchTags}
+            onChangeText={setSearchTags} // Triggers fetchPrompts via useEffect
+            autoCapitalize="none"
+          />
+
+          <View style={styles.controlsContainer}>
+            <Button
+              title={showOnlyFavorites ? "Show All" : "Show Favorites"}
+              onPress={() => setShowOnlyFavorites(!showOnlyFavorites)}
+              color={showOnlyFavorites ? "#ffc107" : Platform.OS === 'ios' ? "#007AFF": "#007bff"}
+            />
+            <Button
+              title={formVisible ? (editingPrompt ? "Cancel Edit" : "Cancel Add") : "Add New Prompt"}
+              onPress={() => {
+                if (formVisible) {
+                  handleCancelForm();
+                } else {
+                  setEditingPrompt(null);
+                  setFormVisible(true);
+                  setTimeout(() => scrollViewRef.current?.scrollTo({ y: 0, animated: true }), 100);
+                }
+              }}
+              color={formVisible ? "#dc3545" : (Platform.OS === 'ios' ? "#007AFF": "#28a745")}
+            />
           </View>
-        ))}
+
+          {formVisible && (
+            <View style={styles.addPromptForm}>
+              <Text style={styles.formTitle}>{editingPrompt ? 'Edit Prompt' : 'Add New Prompt'}</Text>
+              <TextInput placeholder="Prompt Text" value={newPromptText} onChangeText={setNewPromptText} style={styles.input} multiline />
+              <TextInput placeholder="Tool (e.g., GPT-4)" value={newPromptTool} onChangeText={setNewPromptTool} style={styles.input} />
+              <TextInput placeholder="Tags (comma-separated)" value={newPromptTags} onChangeText={setNewPromptTags} style={styles.input} />
+              <Button 
+                title={editingPrompt ? "Update Prompt" : "Submit Prompt"} 
+                onPress={handleSubmitPrompt} 
+                color={Platform.OS === 'ios' ? "#007AFF": "#007bff"}
+              />
+            </View>
+          )}
+
+          {isLoading && <ActivityIndicator size="large" color="#0000ff" style={styles.loader} />}
+          {error && !isLoading && <Text style={styles.errorText}>Error: {error}</Text>}
+
+          {displayedPrompts.length > 0 ? (
+            displayedPrompts.map(prompt => ( // Use displayedPrompts here
+              <View key={prompt.id} style={styles.promptItem}>
+                <View style={styles.promptContent}>
+                  <Text style={styles.promptTool}>{prompt.tool}</Text>
+                  <Text style={styles.promptText}>{prompt.text}</Text>
+                  <Text style={styles.promptTags}>Tags: {prompt.tags.join(', ')}</Text>
+                </View>
+                <View style={styles.promptActions}>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.favoriteButton]}
+                    onPress={() => toggleFavorite(prompt.id, prompt.favorite)}
+                  >
+                    <Text style={[styles.actionButtonText, prompt.favorite && styles.favoritedButtonText]}>
+                      {prompt.favorite ? '★' : '☆'}
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.editButton]}
+                    onPress={() => handleStartEdit(prompt)}
+                  >
+                    <Text style={styles.actionButtonText}>✏️</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.deleteButton]}
+                    onPress={() => handleDeletePrompt(prompt.id)}
+                  >
+                    <Text style={[styles.actionButtonText, styles.deleteButtonText]}>🗑️</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))
+          ) : (
+            !isLoading && <Text style={styles.noPromptsText}>No prompts found for current filters.</Text>
+          )}
+        </View>
       </ScrollView>
-      <View style={styles.addSection}>
-        <TextInput
-          style={[styles.input, styles.textArea]}
-          multiline
-          placeholder="Prompt text"
-          placeholderTextColor="#888"
-          value={text}
-          onChangeText={setText}
-        />
-        <TextInput
-          style={styles.input}
-          placeholder="Tool"
-          placeholderTextColor="#888"
-          value={tool}
-          onChangeText={setTool}
-        />
-        <TextInput
-          style={styles.input}
-          placeholder="Tags"
-          placeholderTextColor="#888"
-          value={tags}
-          onChangeText={setTags}
-        />
-        <TouchableOpacity style={styles.button} onPress={addPrompt}>
-          <Text style={styles.buttonText}>Add Prompt</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
+    </SafeAreaView>
   );
-}
+};
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#121212',
-    padding: 16,
-    paddingTop: 48
-  },
-  title: {
-    color: '#fff',
-    fontSize: 24,
-    textAlign: 'center',
-    marginBottom: 16
-  },
-  searchRow: {
-    flexDirection: 'row',
-    marginBottom: 16
-  },
-  input: {
-    flex: 1,
-    backgroundColor: '#1e1e1e',
-    color: '#fff',
-    paddingHorizontal: 8,
-    paddingVertical: 6,
-    borderRadius: 4,
-    marginBottom: 8
-  },
-  textArea: {
-    height: 80
-  },
-  list: {
-    flex: 1,
-    marginBottom: 16
-  },
-  prompt: {
-    backgroundColor: '#1e1e1e',
-    borderRadius: 4,
-    padding: 12,
-    marginBottom: 12
-  },
-  promptHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 4
-  },
-  tool: {
-    color: '#fff',
-    fontWeight: 'bold'
-  },
-  tags: {
-    color: '#aaa'
-  },
-  text: {
-    color: '#fff'
-  },
-  addSection: {
-    marginTop: 8
-  },
-  button: {
-    backgroundColor: '#4a90e2',
-    paddingVertical: 10,
-    borderRadius: 4,
-    marginTop: 8
-  },
-  buttonText: {
-    color: '#fff',
-    textAlign: 'center',
-    fontWeight: 'bold'
-  }
+  safeArea: { flex: 1, backgroundColor: '#f0f0f0' },
+  containerScrollView: { flex: 1 },
+  container: { flex: 1, padding: 16 },
+  header: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: 16, color: '#333' },
+  searchInput: { height: 40, borderColor: 'gray', borderWidth: 1, borderRadius: 8, paddingHorizontal: 10, marginBottom: 12, backgroundColor: '#fff' },
+  controlsContainer: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 16 },
+  formTitle: { fontSize: 18, fontWeight: '600', marginBottom: 12, textAlign: 'center' },
+  addPromptForm: { backgroundColor: '#fff', padding: 16, borderRadius: 8, marginBottom: 16, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.1, shadowRadius: 4, elevation: 3 },
+  input: { borderColor: 'lightgray', borderWidth: 1, borderRadius: 4, paddingHorizontal: 10, paddingVertical: 8, marginBottom: 10, backgroundColor: '#fff' },
+  loader: { marginVertical: 20 },
+  errorText: { color: 'red', textAlign: 'center', marginBottom: 10, marginTop: 10 },
+  noPromptsText: { textAlign: 'center', marginTop: 20, fontSize: 16, color: '#666' },
+  promptItem: { backgroundColor: '#fff', padding: 12, marginBottom: 12, borderRadius: 8, borderWidth: 1, borderColor: '#ddd', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  promptContent: { flex: 1, marginRight: 8 },
+  promptTool: { fontSize: 16, fontWeight: 'bold', color: Platform.OS === 'ios' ? "#007AFF": '#007bff' },
+  promptText: { fontSize: 14, color: '#333', marginTop: 4, marginBottom: 8 },
+  promptTags: { fontSize: 12, color: '#666' },
+  promptActions: { flexDirection: 'column', justifyContent: 'space-around', alignItems: 'flex-end' },
+  actionButton: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 4, alignItems: 'center', justifyContent: 'center', minWidth: 40, marginBottom: 5 },
+  favoriteButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#007AFF": '#007bff' },
+  editButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#5cb85c" : '#5cb85c'},
+  deleteButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#ff3b30" : '#dc3545' },
+  actionButtonText: { fontSize: 18 },
+  favoritedButtonText: { color: '#ffc107' },
+  deleteButtonText: { color: Platform.OS === 'ios' ? "#ff3b30" : '#dc3545' },
 });
 
+export default App;

--- a/public/app.js
+++ b/public/app.js
@@ -1,81 +1,183 @@
-dlvqre-codex/improve-ui-design-of-promptcache
 const { useState, useEffect } = React;
 
 function App() {
   const [prompts, setPrompts] = useState([]);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(''); // For keyword search
+  const [searchTags, setSearchTags] = useState(''); // New state for tag search
   const [text, setText] = useState('');
   const [tool, setTool] = useState('');
-  const [tags, setTags] = useState('');
+  const [tags, setTags] = useState(''); // For adding/editing prompt tags
+  const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
+  const [editingPrompt, setEditingPrompt] = useState(null);
 
   const loadPrompts = async () => {
-    const res = await fetch('/api/prompts/search?q=' + encodeURIComponent(search));
-    const data = await res.json();
-    setPrompts(data);
-  };
-=======
-async function loadPrompts() {
-  const q = document.getElementById('search').value;
-  const res = await fetch('/api/prompts/search?q=' + encodeURIComponent(q));
-  const data = await res.json();
-  const list = document.getElementById('list');
-  list.innerHTML = '';
-  data.forEach(p => {
-    const li = document.createElement('li');
-    li.innerHTML = `
-      <div class="prompt-header">
-        <span class="tool">${p.tool}</span>
-        <span class="tags">${p.tags.join(', ')}</span>
-      </div>
-      <div class="text">${p.text}</div>
-    `;
-    list.appendChild(li);
-  });
-}
-main
+    try {
+      // Construct the query string, conditionally adding tag if searchTags is not empty
+      let queryString = `q=${encodeURIComponent(search)}`;
+      if (searchTags.trim() !== '') {
+        queryString += `&tag=${encodeURIComponent(searchTags)}`;
+      }
 
+      const res = await fetch(`/api/prompts/search?${queryString}`);
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: `API error: ${res.status}` }));
+        throw new Error(errorData.message);
+      }
+      const data = await res.json();
+      setPrompts(data);
+    } catch (error) {
+      console.error("Failed to load prompts:", error);
+      alert(`Error loading prompts: ${error.message}`);
+    }
+  };
+
+  // useEffect for initial load - should ideally not be triggered by search/searchTags changes here
+  // Let the search button explicitly call loadPrompts
   useEffect(() => {
-    loadPrompts();
+    loadPrompts(); // Initial load with empty search and tags
   }, []);
 
-dlvqre-codex/improve-ui-design-of-promptcache
-  const addPrompt = async (e) => {
+  const handleSubmitPrompt = async (e) => {
     e.preventDefault();
     const tagArray = tags.split(',').map(t => t.trim()).filter(Boolean);
-    await fetch('/api/prompts', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text, tool, tags: tagArray })
-    });
+    const url = editingPrompt ? `/api/prompts/${editingPrompt.id}` : '/api/prompts';
+    const method = editingPrompt ? 'PUT' : 'POST';
+    const body = {
+      text,
+      tool,
+      tags: tagArray,
+      favorite: editingPrompt ? editingPrompt.favorite : false,
+    };
+
+    try {
+      const res = await fetch(url, {
+        method: method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Unknown error occurred' }));
+        throw new Error(errorData.message || `Failed to ${editingPrompt ? 'update' : 'add'} prompt`);
+      }
+      
+      const updatedOrNewPrompt = await res.json();
+
+      if (editingPrompt) {
+        setPrompts(prevPrompts =>
+          prevPrompts.map(p => (p.id === editingPrompt.id ? updatedOrNewPrompt : p))
+        );
+      } else {
+        loadPrompts(); // Reload all prompts after adding
+      }
+      setEditingPrompt(null);
+      setText('');
+      setTool('');
+      setTags('');
+    } catch (error) {
+      console.error(`Error ${editingPrompt ? 'updating' : 'adding'} prompt:`, error);
+      alert(`Error ${editingPrompt ? 'updating' : 'adding'} prompt: ${error.message}`);
+    }
+  };
+
+  // Renamed from handleSearch to reflect it's now a general search trigger
+  const handleExecuteSearch = () => {
+    loadPrompts(); 
+  };
+
+  const toggleFavorite = async (id, currentFavoriteStatus) => {
+    try {
+      const res = await fetch(`/api/prompts/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ favorite: !currentFavoriteStatus })
+      });
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Failed to update favorite status' }));
+        throw new Error(errorData.message);
+      }
+      const updatedPrompt = await res.json();
+      setPrompts(prevPrompts =>
+        prevPrompts.map(p => (p.id === id ? updatedPrompt : p))
+      );
+    } catch (error) {
+      console.error('Error toggling favorite:', error);
+      alert(`Error toggling favorite: ${error.message}`);
+    }
+  };
+
+  const handleEdit = (prompt) => {
+    setEditingPrompt(prompt);
+    setText(prompt.text);
+    setTool(prompt.tool);
+    setTags(prompt.tags.join(', '));
+  };
+
+  const handleCancelEdit = () => {
+    setEditingPrompt(null);
     setText('');
     setTool('');
     setTags('');
-    loadPrompts();
   };
+
+  const handleDeletePrompt = async (promptId) => {
+    if (window.confirm('Are you sure you want to delete this prompt?')) {
+      try {
+        const res = await fetch(`/api/prompts/${promptId}`, {
+          method: 'DELETE',
+        });
+        if (res.ok) {
+          setPrompts(prevPrompts => prevPrompts.filter(p => p.id !== promptId));
+        } else {
+          const errorData = await res.json().catch(() => ({ message: 'Failed to delete prompt.' }));
+          console.error('Failed to delete prompt:', errorData.message);
+          alert(`Error: ${errorData.message}`);
+        }
+      } catch (error) {
+        console.error('Error deleting prompt:', error);
+        alert(`Error deleting prompt: ${error.message}`);
+      }
+    }
+  };
+
+  const filteredPromptsByFavorite = showOnlyFavorites
+    ? prompts.filter(p => p.favorite) // This filters results from API
+    : prompts;
 
   return (
     <div className="app">
       <header className="header">
         <h1>PromptCache</h1>
-        <div className="search">
-          <input
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            placeholder="Search prompts"
-            aria-label="Search prompts"
-          />
-          <button onClick={loadPrompts}>Search</button>
+        <div className="search-controls">
+          <div className="search-keywords">
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search by keyword..."
+              aria-label="Search by keyword"
+            />
+          </div>
+          <div className="search-tags">
+            <input
+              value={searchTags}
+              onChange={e => setSearchTags(e.target.value)}
+              placeholder="Filter by tags (e.g., js, python)"
+              aria-label="Filter by tags"
+            />
+          </div>
+          <button onClick={handleExecuteSearch}>Search</button>
         </div>
       </header>
       <main>
         <section className="add">
-          <h2>Add Prompt</h2>
-          <form onSubmit={addPrompt} id="newPrompt">
+          <h2>{editingPrompt ? 'Edit Prompt' : 'Add Prompt'}</h2>
+          <form onSubmit={handleSubmitPrompt} id="newPrompt">
             <label>Prompt Text
               <textarea
                 value={text}
                 onChange={e => setText(e.target.value)}
                 placeholder="Prompt text"
+                required
               />
             </label>
             <label>Tool
@@ -89,19 +191,57 @@ dlvqre-codex/improve-ui-design-of-promptcache
               <input
                 value={tags}
                 onChange={e => setTags(e.target.value)}
-                placeholder="e.g. copywriting, design"
+                placeholder="e.g. copywriting, design (comma-separated)"
               />
             </label>
-            <button type="submit">Add Prompt</button>
+            <button type="submit">{editingPrompt ? 'Update Prompt' : 'Add Prompt'}</button>
+            {editingPrompt && (
+              <button type="button" onClick={handleCancelEdit} style={{ marginLeft: '10px' }}>
+                Cancel Edit
+              </button>
+            )}
           </form>
+        </section>
+        <section className="list-controls">
+          <label>
+            <input
+              type="checkbox"
+              checked={showOnlyFavorites}
+              onChange={e => setShowOnlyFavorites(e.target.checked)}
+            />
+            Show Favorites Only
+          </label>
         </section>
         <section className="list">
           <ul id="list">
-            {prompts.map(p => (
+            {filteredPromptsByFavorite.map(p => ( // Use the client-side filtered list
               <li key={p.id}>
                 <div className="prompt-header">
                   <span className="tool">{p.tool}</span>
                   <span className="tags">{p.tags.join(', ')}</span>
+                  <button
+                    onClick={() => toggleFavorite(p.id, p.favorite)}
+                    className={`favorite-btn ${p.favorite ? 'favorited' : ''}`}
+                    title={p.favorite ? 'Unfavorite' : 'Favorite'}
+                  >
+                    {p.favorite ? '★' : '☆'}
+                  </button>
+                  <button
+                    onClick={() => handleEdit(p)}
+                    className="edit-btn"
+                    title="Edit Prompt"
+                    style={{ marginLeft: '5px' }}
+                  >
+                    ✏️ Edit
+                  </button>
+                  <button
+                    onClick={() => handleDeletePrompt(p.id)}
+                    className="delete-btn"
+                    title="Delete Prompt"
+                    style={{ marginLeft: '5px', color: 'red' }}
+                  >
+                    🗑️ Delete
+                  </button>
                 </div>
                 <div className="text">{p.text}</div>
               </li>
@@ -114,8 +254,3 @@ dlvqre-codex/improve-ui-design-of-promptcache
 }
 
 ReactDOM.render(<App />, document.getElementById('root'));
-=======
-document.getElementById('searchBtn').addEventListener('click', loadPrompts);
-
-loadPrompts();
-main


### PR DESCRIPTION
This commit introduces several enhancements to the PromptCache application:

1.  **Favorite Prompts**:
    *   You can mark prompts as favorites in both web and mobile UIs.
    *   A filter to show only favorite prompts is available.
    *   Backend `favorite` field and update logic were already present.

2.  **Edit Prompts**:
    *   You can edit the text, tool, and tags of existing prompts.
    *   Favorite status is preserved during edits.
    *   Implemented in both web and mobile UIs, utilizing the existing backend `PUT` endpoint.

3.  **Delete Prompts**:
    *   Backend: Added a `DELETE /api/prompts/:id` endpoint.
    *   Web & Mobile: You can delete prompts with confirmation.

4.  **Enhanced Tag Search**:
    *   Backend: `/api/prompts/search` now supports multiple comma-separated tags.
    *   Backend: Keyword search now also includes prompt tool and tags.
    *   Web & Mobile: UI updated with separate input fields for keyword and tag searches.

5.  **Code Resolution**:
    *   Resolved a merge conflict in `public/app.js`, standardizing on the React-based implementation.

These changes significantly improve the usability and functionality of the prompt management application.