### PR TITLE
feat: Implement prompt usage tracking and history

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -12,25 +12,40 @@ import {
   ActivityIndicator,
   Platform,
 } from 'react-native';
+import { Picker } from '@react-native-picker/picker'; // Standard picker
+import * as Clipboard from 'expo-clipboard'; // For clipboard access
 
-const API_BASE = 'http://localhost:3000'; // Ensure this is your actual API base URL
+const API_BASE = 'http://localhost:3000';
 
 const App = () => {
   const [prompts, setPrompts] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchTags, setSearchTags] = useState(''); // New state for tag search input
+  const [searchTags, setSearchTags] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
 
   const [formVisible, setFormVisible] = useState(false);
   const [newPromptText, setNewPromptText] = useState('');
   const [newPromptTool, setNewPromptTool] = useState('');
-  const [newPromptTags, setNewPromptTags] = useState(''); // For adding/editing prompt tags
+  const [newPromptTags, setNewPromptTags] = useState('');
 
   const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState(null);
+  
+  // --- New state for sorting ---
+  const [sortCriteria, setSortCriteria] = useState('dateAdded'); // Default sort
 
   const scrollViewRef = useRef(null);
+
+  const formatDate = (dateString) => {
+    if (!dateString) return "Never";
+    try {
+      const date = new Date(dateString);
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    } catch {
+      return "Invalid Date";
+    }
+  };
 
   const fetchPrompts = useCallback(async (keywordQuery = '', tagsQuery = '') => {
     setIsLoading(true);
@@ -40,13 +55,18 @@ const App = () => {
       if (tagsQuery.trim() !== '') {
         queryString += `&tag=${encodeURIComponent(tagsQuery)}`;
       }
-
       const response = await fetch(`${API_BASE}/api/prompts/search?${queryString}`);
       if (!response.ok) {
         const errData = await response.json().catch(() => ({ message: `HTTP error! status: ${response.status}` }));
         throw new Error(errData.message);
       }
-      const data = await response.json();
+      let data = await response.json();
+      // Initialize usageCount/lastUsed if missing (for older data)
+      data = data.map(p => ({
+        ...p,
+        usageCount: p.usageCount || 0,
+        lastUsed: p.lastUsed || null,
+      }));
       setPrompts(data);
     } catch (e) {
       setError(e.message);
@@ -56,9 +76,7 @@ const App = () => {
     }
   }, []);
 
-  // useEffect to fetch prompts when searchQuery or searchTags change
   useEffect(() => {
-    // Debounce or delay could be added here if desired, for now, it fetches on each change
     fetchPrompts(searchQuery, searchTags);
   }, [fetchPrompts, searchQuery, searchTags]);
 
@@ -69,41 +87,31 @@ const App = () => {
     }
     setIsLoading(true);
     const tagsArray = newPromptTags.split(',').map(tag => tag.trim()).filter(tag => tag);
-    const url = editingPrompt 
-      ? `${API_BASE}/api/prompts/${editingPrompt.id}` 
-      : `${API_BASE}/api/prompts`;
+    const url = editingPrompt ? `${API_BASE}/api/prompts/${editingPrompt.id}` : `${API_BASE}/api/prompts`;
     const method = editingPrompt ? 'PUT' : 'POST';
-    const body = editingPrompt 
-      ? { text: newPromptText, tool: newPromptTool, tags: tagsArray, favorite: editingPrompt.favorite }
-      : { text: newPromptText, tool: newPromptTool, tags: tagsArray, favorite: false };
+    // Backend handles usageCount and lastUsed on creation
+    const body = {
+      text: newPromptText,
+      tool: newPromptTool,
+      tags: tagsArray,
+      favorite: editingPrompt ? editingPrompt.favorite : false,
+    };
 
     try {
-      const response = await fetch(url, {
-        method: method,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
+      const response = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
       if (!response.ok) {
         const errData = await response.json().catch(() => ({ message: 'Unknown API error' }));
         throw new Error(errData.message || `HTTP error! status: ${response.status}`);
       }
       const updatedOrNewPrompt = await response.json();
       if (editingPrompt) {
-        setPrompts(prevPrompts =>
-          prevPrompts.map(p => (p.id === editingPrompt.id ? updatedOrNewPrompt : p))
-        );
+        setPrompts(prev => prev.map(p => (p.id === editingPrompt.id ? { ...p, ...updatedOrNewPrompt } : p)));
       } else {
-        // Refresh with current search terms after adding
-        fetchPrompts(searchQuery, searchTags); 
+        fetchPrompts(searchQuery, searchTags); // Refresh to get new prompt with defaults
       }
-      setNewPromptText('');
-      setNewPromptTool('');
-      setNewPromptTags('');
-      setEditingPrompt(null);
-      setFormVisible(false);
+      setNewPromptText(''); setNewPromptTool(''); setNewPromptTags('');
+      setEditingPrompt(null); setFormVisible(false);
     } catch (e) {
-      setError(e.message);
       Alert.alert("Error", `Failed to ${editingPrompt ? 'update' : 'add'} prompt: ${e.message}`);
     } finally {
       setIsLoading(false);
@@ -122,15 +130,42 @@ const App = () => {
         throw new Error(errData.message || `HTTP error! status: ${response.status}`);
       }
       const updatedPrompt = await response.json();
-      setPrompts(prevPrompts =>
-        prevPrompts.map(p => (p.id === id ? updatedPrompt : p))
-      );
+      setPrompts(prev => prev.map(p => (p.id === id ? { ...p, ...updatedPrompt } : p)));
     } catch (e) {
       Alert.alert("Error", `Failed to update favorite status: ${e.message}`);
     }
   };
+  
+  // --- Log Usage Function ---
+  const handleLogUsage = async (promptToLog) => {
+    try {
+      await Clipboard.setStringAsync(promptToLog.text); // Use setStringAsync for expo-clipboard v~12+
+      Alert.alert("Copied!", "Prompt text copied to clipboard.");
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+      Alert.alert("Copy Error", "Failed to copy text. See console.");
+    }
 
-  const handleStartEdit = (prompt) => {
+    try {
+      setIsLoading(true);
+      const response = await fetch(`${API_BASE}/api/prompts/${promptToLog.id}/logusage`, { method: 'POST' });
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ message: 'Unknown API error' }));
+        throw new Error(errData.message || `HTTP error! status: ${response.status}`);
+      }
+      const updatedPrompt = await response.json();
+      setPrompts(prevPrompts =>
+        prevPrompts.map(p => (p.id === updatedPrompt.id ? { ...p, ...updatedPrompt } : p))
+      );
+    } catch (e) {
+      Alert.alert("Error", `Failed to log usage: ${e.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+
+  const handleStartEdit = (prompt) => { /* ... (same as before) ... */ 
     setEditingPrompt(prompt);
     setNewPromptText(prompt.text);
     setNewPromptTool(prompt.tool);
@@ -138,50 +173,62 @@ const App = () => {
     setFormVisible(true);
     setTimeout(() => scrollViewRef.current?.scrollTo({ y: 0, animated: true }), 100);
   };
-
-  const handleCancelForm = () => {
+  const handleCancelForm = () => { /* ... (same as before) ... */ 
     setEditingPrompt(null);
     setNewPromptText('');
     setNewPromptTool('');
     setNewPromptTags('');
     setFormVisible(false);
   };
-
-  const handleDeletePrompt = (promptId) => {
-    Alert.alert(
-      "Delete Prompt",
-      "Are you sure you want to delete this prompt?",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
+  const handleDeletePrompt = (promptId) => { /* ... (same as before) ... */ 
+    Alert.alert( "Delete Prompt", "Are you sure you want to delete this prompt?",
+      [ { text: "Cancel", style: "cancel" },
+        { text: "Delete", style: "destructive", onPress: async () => {
             setIsLoading(true);
             try {
-              const response = await fetch(`${API_BASE}/api/prompts/${promptId}`, {
-                method: 'DELETE',
-              });
+              const response = await fetch(`${API_BASE}/api/prompts/${promptId}`, { method: 'DELETE' });
               if (!response.ok) {
                 const errData = await response.json().catch(() => ({ message: 'Unknown API error during delete' }));
                 throw new Error(errData.message || `HTTP error! status: ${response.status}`);
               }
               setPrompts(prevPrompts => prevPrompts.filter(p => p.id !== promptId));
-            } catch (e) {
-              Alert.alert("Error", `Failed to delete prompt: ${e.message}`);
-            } finally {
-              setIsLoading(false);
-            }
+            } catch (e) { Alert.alert("Error", `Failed to delete prompt: ${e.message}`); } 
+            finally { setIsLoading(false); }
           },
         },
       ]
     );
   };
   
-  // Client-side filtering for favorites, applied to the API results
-  const displayedPrompts = showOnlyFavorites
-    ? prompts.filter(p => p.favorite)
-    : prompts;
+  // --- Sorting and Filtering Logic for Display ---
+  let displayedPrompts = [...prompts];
+
+  // 1. Filter by favorites
+  if (showOnlyFavorites) {
+    displayedPrompts = displayedPrompts.filter(p => p.favorite);
+  }
+
+  // 2. Sort
+  if (sortCriteria === 'usageCountDesc') {
+    displayedPrompts.sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0));
+  } else if (sortCriteria === 'usageCountAsc') {
+    displayedPrompts.sort((a, b) => (a.usageCount || 0) - (b.usageCount || 0));
+  } else if (sortCriteria === 'lastUsedDesc') {
+    displayedPrompts.sort((a, b) => {
+      const dateA = a.lastUsed ? new Date(a.lastUsed).getTime() : 0; // Treat null as very old
+      const dateB = b.lastUsed ? new Date(b.lastUsed).getTime() : 0;
+      return dateB - dateA;
+    });
+  } else if (sortCriteria === 'lastUsedAsc') {
+    displayedPrompts.sort((a, b) => {
+      const dateA = a.lastUsed ? new Date(a.lastUsed).getTime() : 0;
+      const dateB = b.lastUsed ? new Date(b.lastUsed).getTime() : 0;
+      return dateA - dateB;
+    });
+  } else if (sortCriteria === 'dateAdded') {
+    displayedPrompts.sort((a, b) => a.id - b.id); // Assuming IDs are sequential
+  }
+
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -189,53 +236,39 @@ const App = () => {
         <View style={styles.container}>
           <Text style={styles.header}>PromptCache Mobile</Text>
 
-          <TextInput
-            style={styles.searchInput}
-            placeholder="Search by keyword..."
-            value={searchQuery}
-            onChangeText={setSearchQuery} // Triggers fetchPrompts via useEffect
-          />
-          {/* New TextInput for tags */}
-          <TextInput
-            style={styles.searchInput} // Reusing similar style
-            placeholder="Filter by tags (e.g., js,react)"
-            value={searchTags}
-            onChangeText={setSearchTags} // Triggers fetchPrompts via useEffect
-            autoCapitalize="none"
-          />
-
-          <View style={styles.controlsContainer}>
-            <Button
-              title={showOnlyFavorites ? "Show All" : "Show Favorites"}
-              onPress={() => setShowOnlyFavorites(!showOnlyFavorites)}
-              color={showOnlyFavorites ? "#ffc107" : Platform.OS === 'ios' ? "#007AFF": "#007bff"}
-            />
-            <Button
-              title={formVisible ? (editingPrompt ? "Cancel Edit" : "Cancel Add") : "Add New Prompt"}
-              onPress={() => {
-                if (formVisible) {
-                  handleCancelForm();
-                } else {
-                  setEditingPrompt(null);
-                  setFormVisible(true);
-                  setTimeout(() => scrollViewRef.current?.scrollTo({ y: 0, animated: true }), 100);
-                }
-              }}
-              color={formVisible ? "#dc3545" : (Platform.OS === 'ios' ? "#007AFF": "#28a745")}
-            />
+          <TextInput style={styles.searchInput} placeholder="Search by keyword..." value={searchQuery} onChangeText={setSearchQuery} />
+          <TextInput style={styles.searchInput} placeholder="Filter by tags (e.g., js,react)" value={searchTags} onChangeText={setSearchTags} autoCapitalize="none" />
+          
+          {/* --- Sort Picker --- */}
+          <View style={styles.pickerContainer}>
+            <Text style={styles.pickerLabel}>Sort by:</Text>
+            <Picker
+              selectedValue={sortCriteria}
+              style={styles.picker}
+              onValueChange={(itemValue) => setSortCriteria(itemValue)}
+              prompt="Sort Prompts By"
+            >
+              <Picker.Item label="Date Added" value="dateAdded" />
+              <Picker.Item label="Usage Count (Most First)" value="usageCountDesc" />
+              <Picker.Item label="Usage Count (Least First)" value="usageCountAsc" />
+              <Picker.Item label="Last Used (Newest First)" value="lastUsedDesc" />
+              <Picker.Item label="Last Used (Oldest First)" value="lastUsedAsc" />
+            </Picker>
           </View>
 
-          {formVisible && (
+
+          <View style={styles.controlsContainer}>
+            <Button title={showOnlyFavorites ? "Show All" : "Show Favorites"} onPress={() => setShowOnlyFavorites(!showOnlyFavorites)} color={showOnlyFavorites ? "#ffc107" : Platform.OS === 'ios' ? "#007AFF": "#007bff"} />
+            <Button title={formVisible ? (editingPrompt ? "Cancel Edit" : "Cancel Add") : "Add New Prompt"} onPress={() => { if (formVisible) { handleCancelForm(); } else { setEditingPrompt(null); setFormVisible(true); setTimeout(() => scrollViewRef.current?.scrollTo({ y: 0, animated: true }), 100); }}} color={formVisible ? "#dc3545" : (Platform.OS === 'ios' ? "#007AFF": "#28a745")} />
+          </View>
+
+          {formVisible && ( /* ... Form remains the same ... */ 
             <View style={styles.addPromptForm}>
               <Text style={styles.formTitle}>{editingPrompt ? 'Edit Prompt' : 'Add New Prompt'}</Text>
               <TextInput placeholder="Prompt Text" value={newPromptText} onChangeText={setNewPromptText} style={styles.input} multiline />
               <TextInput placeholder="Tool (e.g., GPT-4)" value={newPromptTool} onChangeText={setNewPromptTool} style={styles.input} />
               <TextInput placeholder="Tags (comma-separated)" value={newPromptTags} onChangeText={setNewPromptTags} style={styles.input} />
-              <Button 
-                title={editingPrompt ? "Update Prompt" : "Submit Prompt"} 
-                onPress={handleSubmitPrompt} 
-                color={Platform.OS === 'ios' ? "#007AFF": "#007bff"}
-              />
+              <Button title={editingPrompt ? "Update Prompt" : "Submit Prompt"} onPress={handleSubmitPrompt} color={Platform.OS === 'ios' ? "#007AFF": "#007bff"} />
             </View>
           )}
 
@@ -243,40 +276,30 @@ const App = () => {
           {error && !isLoading && <Text style={styles.errorText}>Error: {error}</Text>}
 
           {displayedPrompts.length > 0 ? (
-            displayedPrompts.map(prompt => ( // Use displayedPrompts here
+            displayedPrompts.map(prompt => (
               <View key={prompt.id} style={styles.promptItem}>
                 <View style={styles.promptContent}>
                   <Text style={styles.promptTool}>{prompt.tool}</Text>
                   <Text style={styles.promptText}>{prompt.text}</Text>
                   <Text style={styles.promptTags}>Tags: {prompt.tags.join(', ')}</Text>
+                  {/* --- Usage Info --- */}
+                  <View style={styles.usageInfoContainer}>
+                    <Text style={styles.usageText}>Usage: {prompt.usageCount || 0}</Text>
+                    <Text style={styles.usageText}>Last: {formatDate(prompt.lastUsed)}</Text>
+                  </View>
                 </View>
                 <View style={styles.promptActions}>
-                  <TouchableOpacity
-                    style={[styles.actionButton, styles.favoriteButton]}
-                    onPress={() => toggleFavorite(prompt.id, prompt.favorite)}
-                  >
-                    <Text style={[styles.actionButtonText, prompt.favorite && styles.favoritedButtonText]}>
-                      {prompt.favorite ? '★' : '☆'}
-                    </Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.actionButton, styles.editButton]}
-                    onPress={() => handleStartEdit(prompt)}
-                  >
-                    <Text style={styles.actionButtonText}>✏️</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.actionButton, styles.deleteButton]}
-                    onPress={() => handleDeletePrompt(prompt.id)}
-                  >
-                    <Text style={[styles.actionButtonText, styles.deleteButtonText]}>🗑️</Text>
-                  </TouchableOpacity>
+                  <TouchableOpacity style={[styles.actionButton, styles.favoriteButton]} onPress={() => toggleFavorite(prompt.id, prompt.favorite)}><Text style={[styles.actionButtonText, prompt.favorite && styles.favoritedButtonText]}>{prompt.favorite ? '★' : '☆'}</Text></TouchableOpacity>
+                  <TouchableOpacity style={[styles.actionButton, styles.editButton]} onPress={() => handleStartEdit(prompt)}><Text style={styles.actionButtonText}>✏️</Text></TouchableOpacity>
+                  <TouchableOpacity style={[styles.actionButton, styles.deleteButton]} onPress={() => handleDeletePrompt(prompt.id)}><Text style={[styles.actionButtonText, styles.deleteButtonText]}>🗑️</Text></TouchableOpacity>
                 </View>
+                {/* --- Copy & Log Use Button --- */}
+                <TouchableOpacity style={styles.copyLogButton} onPress={() => handleLogUsage(prompt)}>
+                  <Text style={styles.copyLogButtonText}>📋 Copy & Log Use</Text>
+                </TouchableOpacity>
               </View>
             ))
-          ) : (
-            !isLoading && <Text style={styles.noPromptsText}>No prompts found for current filters.</Text>
-          )}
+          ) : ( !isLoading && <Text style={styles.noPromptsText}>No prompts found for current filters.</Text> )}
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -287,8 +310,27 @@ const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#f0f0f0' },
   containerScrollView: { flex: 1 },
   container: { flex: 1, padding: 16 },
-  header: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: 16, color: '#333' },
-  searchInput: { height: 40, borderColor: 'gray', borderWidth: 1, borderRadius: 8, paddingHorizontal: 10, marginBottom: 12, backgroundColor: '#fff' },
+  header: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: 10, color: '#333' },
+  searchInput: { height: 40, borderColor: 'gray', borderWidth: 1, borderRadius: 8, paddingHorizontal: 10, marginBottom: 10, backgroundColor: '#fff' },
+  pickerContainer: {
+    marginBottom: 12,
+    borderColor: 'gray',
+    borderWidth: 1,
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    height: Platform.OS === 'ios' ? 120 : 50, // iOS Picker is taller by default
+    justifyContent: 'center',
+  },
+  pickerLabel: {
+    fontSize: 12,
+    color: 'gray',
+    paddingHorizontal: 10,
+    paddingTop: Platform.OS === 'ios' ? 5 : 0, // Adjust label for iOS
+  },
+  picker: {
+    height: Platform.OS === 'ios' ? 100 : 50, // iOS needs more height for wheel
+    width: '100%',
+  },
   controlsContainer: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 16 },
   formTitle: { fontSize: 18, fontWeight: '600', marginBottom: 12, textAlign: 'center' },
   addPromptForm: { backgroundColor: '#fff', padding: 16, borderRadius: 8, marginBottom: 16, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.1, shadowRadius: 4, elevation: 3 },
@@ -296,19 +338,30 @@ const styles = StyleSheet.create({
   loader: { marginVertical: 20 },
   errorText: { color: 'red', textAlign: 'center', marginBottom: 10, marginTop: 10 },
   noPromptsText: { textAlign: 'center', marginTop: 20, fontSize: 16, color: '#666' },
-  promptItem: { backgroundColor: '#fff', padding: 12, marginBottom: 12, borderRadius: 8, borderWidth: 1, borderColor: '#ddd', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  promptContent: { flex: 1, marginRight: 8 },
+  promptItem: { backgroundColor: '#fff', padding: 12, marginBottom: 12, borderRadius: 8, borderWidth: 1, borderColor: '#ddd' }, // Removed flex row for vertical layout of content + actions
+  promptContent: { marginBottom: 8 }, // Added margin for spacing before copy button
   promptTool: { fontSize: 16, fontWeight: 'bold', color: Platform.OS === 'ios' ? "#007AFF": '#007bff' },
-  promptText: { fontSize: 14, color: '#333', marginTop: 4, marginBottom: 8 },
-  promptTags: { fontSize: 12, color: '#666' },
-  promptActions: { flexDirection: 'column', justifyContent: 'space-around', alignItems: 'flex-end' },
-  actionButton: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 4, alignItems: 'center', justifyContent: 'center', minWidth: 40, marginBottom: 5 },
+  promptText: { fontSize: 14, color: '#333', marginTop: 4, marginBottom: 4 },
+  promptTags: { fontSize: 12, color: '#666', marginBottom: 6 },
+  usageInfoContainer: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 8 },
+  usageText: { fontSize: 12, color: '#444' },
+  promptActions: { flexDirection: 'row', justifyContent: 'flex-end', alignItems: 'center', marginBottom: 8 }, // Kept actions in a row, at the end
+  actionButton: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 4, alignItems: 'center', justifyContent: 'center', minWidth: 40, marginLeft: 8 }, // Added marginLeft for spacing between action buttons
   favoriteButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#007AFF": '#007bff' },
   editButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#5cb85c" : '#5cb85c'},
   deleteButton: { borderWidth: 1, borderColor: Platform.OS === 'ios' ? "#ff3b30" : '#dc3545' },
   actionButtonText: { fontSize: 18 },
   favoritedButtonText: { color: '#ffc107' },
   deleteButtonText: { color: Platform.OS === 'ios' ? "#ff3b30" : '#dc3545' },
+  copyLogButton: {
+    backgroundColor: Platform.OS === 'ios' ? '#e0e0e0' : '#ddd',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  copyLogButtonText: { fontSize: 14, color: '#333', fontWeight: '500' },
 });
 
 export default App;

--- a/public/app.js
+++ b/public/app.js
@@ -2,39 +2,51 @@ const { useState, useEffect } = React;
 
 function App() {
   const [prompts, setPrompts] = useState([]);
-  const [search, setSearch] = useState(''); // For keyword search
-  const [searchTags, setSearchTags] = useState(''); // New state for tag search
+  const [search, setSearch] = useState('');
+  const [searchTags, setSearchTags] = useState('');
   const [text, setText] = useState('');
   const [tool, setTool] = useState('');
-  const [tags, setTags] = useState(''); // For adding/editing prompt tags
+  const [tags, setTags] = useState('');
   const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState(null);
+  const [sortCriteria, setSortCriteria] = useState('dateAdded'); // New state for sorting
+
+  const formatLastUsed = (dateString) => {
+    if (!dateString) return "Not used yet";
+    try {
+      return new Date(dateString).toLocaleDateString('en-CA'); // YYYY-MM-DD format
+    } catch (e) {
+      return "Invalid date";
+    }
+  };
 
   const loadPrompts = async () => {
     try {
-      // Construct the query string, conditionally adding tag if searchTags is not empty
       let queryString = `q=${encodeURIComponent(search)}`;
       if (searchTags.trim() !== '') {
         queryString += `&tag=${encodeURIComponent(searchTags)}`;
       }
-
       const res = await fetch(`/api/prompts/search?${queryString}`);
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ message: `API error: ${res.status}` }));
         throw new Error(errorData.message);
       }
       const data = await res.json();
-      setPrompts(data);
+      // Initialize usageCount/lastUsed if missing from older data
+      const processedData = data.map(p => ({
+        ...p,
+        usageCount: p.usageCount || 0,
+        lastUsed: p.lastUsed || null
+      }));
+      setPrompts(processedData);
     } catch (error) {
       console.error("Failed to load prompts:", error);
       alert(`Error loading prompts: ${error.message}`);
     }
   };
 
-  // useEffect for initial load - should ideally not be triggered by search/searchTags changes here
-  // Let the search button explicitly call loadPrompts
   useEffect(() => {
-    loadPrompts(); // Initial load with empty search and tags
+    loadPrompts();
   }, []);
 
   const handleSubmitPrompt = async (e) => {
@@ -47,6 +59,7 @@ function App() {
       tool,
       tags: tagArray,
       favorite: editingPrompt ? editingPrompt.favorite : false,
+      // usageCount and lastUsed are handled by backend on creation/logusage
     };
 
     try {
@@ -55,20 +68,17 @@ function App() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)
       });
-
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ message: 'Unknown error occurred' }));
         throw new Error(errorData.message || `Failed to ${editingPrompt ? 'update' : 'add'} prompt`);
       }
-      
       const updatedOrNewPrompt = await res.json();
-
       if (editingPrompt) {
         setPrompts(prevPrompts =>
-          prevPrompts.map(p => (p.id === editingPrompt.id ? updatedOrNewPrompt : p))
+          prevPrompts.map(p => (p.id === editingPrompt.id ? { ...p, ...updatedOrNewPrompt } : p))
         );
       } else {
-        loadPrompts(); // Reload all prompts after adding
+        loadPrompts(); // Reload all to get the new prompt with correct defaults
       }
       setEditingPrompt(null);
       setText('');
@@ -80,9 +90,8 @@ function App() {
     }
   };
 
-  // Renamed from handleSearch to reflect it's now a general search trigger
   const handleExecuteSearch = () => {
-    loadPrompts(); 
+    loadPrompts();
   };
 
   const toggleFavorite = async (id, currentFavoriteStatus) => {
@@ -98,7 +107,7 @@ function App() {
       }
       const updatedPrompt = await res.json();
       setPrompts(prevPrompts =>
-        prevPrompts.map(p => (p.id === id ? updatedPrompt : p))
+        prevPrompts.map(p => (p.id === id ? { ...p, ...updatedPrompt } : p))
       );
     } catch (error) {
       console.error('Error toggling favorite:', error);
@@ -123,26 +132,76 @@ function App() {
   const handleDeletePrompt = async (promptId) => {
     if (window.confirm('Are you sure you want to delete this prompt?')) {
       try {
-        const res = await fetch(`/api/prompts/${promptId}`, {
-          method: 'DELETE',
-        });
+        const res = await fetch(`/api/prompts/${promptId}`, { method: 'DELETE' });
         if (res.ok) {
           setPrompts(prevPrompts => prevPrompts.filter(p => p.id !== promptId));
         } else {
           const errorData = await res.json().catch(() => ({ message: 'Failed to delete prompt.' }));
-          console.error('Failed to delete prompt:', errorData.message);
           alert(`Error: ${errorData.message}`);
         }
       } catch (error) {
-        console.error('Error deleting prompt:', error);
         alert(`Error deleting prompt: ${error.message}`);
       }
     }
   };
 
-  const filteredPromptsByFavorite = showOnlyFavorites
-    ? prompts.filter(p => p.favorite) // This filters results from API
-    : prompts;
+  // --- Log Usage Function ---
+  const handleLogUsage = async (promptToLog) => {
+    try {
+      await navigator.clipboard.writeText(promptToLog.text);
+      alert('Prompt text copied to clipboard!');
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+      alert('Failed to copy text to clipboard. See console for details.');
+    }
+
+    try {
+      const res = await fetch(`/api/prompts/${promptToLog.id}/logusage`, { method: 'POST' });
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Failed to log usage.' }));
+        throw new Error(errorData.message);
+      }
+      const updatedPrompt = await res.json();
+      setPrompts(prevPrompts =>
+        prevPrompts.map(p => (p.id === updatedPrompt.id ? { ...p, ...updatedPrompt } : p))
+      );
+    } catch (error) {
+      console.error('Error logging usage:', error);
+      alert(`Error logging usage: ${error.message}`);
+    }
+  };
+
+  // --- Sorting and Filtering Logic ---
+  let processedPrompts = [...prompts];
+
+  // 1. Filter by favorites (client-side)
+  if (showOnlyFavorites) {
+    processedPrompts = processedPrompts.filter(p => p.favorite);
+  }
+
+  // 2. Sort (client-side)
+  if (sortCriteria === 'usageCountDesc') {
+    processedPrompts.sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0));
+  } else if (sortCriteria === 'usageCountAsc') {
+    processedPrompts.sort((a, b) => (a.usageCount || 0) - (b.usageCount || 0));
+  } else if (sortCriteria === 'lastUsedDesc') {
+    processedPrompts.sort((a, b) => {
+      const dateA = a.lastUsed ? new Date(a.lastUsed) : new Date(0); // Treat null as very old
+      const dateB = b.lastUsed ? new Date(b.lastUsed) : new Date(0);
+      return dateB - dateA;
+    });
+  } else if (sortCriteria === 'lastUsedAsc') {
+    processedPrompts.sort((a, b) => {
+      const dateA = a.lastUsed ? new Date(a.lastUsed) : new Date(0);
+      const dateB = b.lastUsed ? new Date(b.lastUsed) : new Date(0);
+      return dateA - dateB;
+    });
+  } else if (sortCriteria === 'dateAdded') {
+    // Assuming prompts are fetched in order of addition or have an ID that reflects this
+    // If IDs are sequential and increasing, sorting by ID ascending would be "dateAdded"
+    processedPrompts.sort((a, b) => a.id - b.id); 
+  }
+
 
   return (
     <div className="app">
@@ -150,20 +209,10 @@ function App() {
         <h1>PromptCache</h1>
         <div className="search-controls">
           <div className="search-keywords">
-            <input
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              placeholder="Search by keyword..."
-              aria-label="Search by keyword"
-            />
+            <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search by keyword..." />
           </div>
           <div className="search-tags">
-            <input
-              value={searchTags}
-              onChange={e => setSearchTags(e.target.value)}
-              placeholder="Filter by tags (e.g., js, python)"
-              aria-label="Filter by tags"
-            />
+            <input value={searchTags} onChange={e => setSearchTags(e.target.value)} placeholder="Filter by tags (e.g., js, python)" />
           </div>
           <button onClick={handleExecuteSearch}>Search</button>
         </div>
@@ -171,79 +220,52 @@ function App() {
       <main>
         <section className="add">
           <h2>{editingPrompt ? 'Edit Prompt' : 'Add Prompt'}</h2>
+          {/* Form for adding/editing prompts remains the same */}
           <form onSubmit={handleSubmitPrompt} id="newPrompt">
-            <label>Prompt Text
-              <textarea
-                value={text}
-                onChange={e => setText(e.target.value)}
-                placeholder="Prompt text"
-                required
-              />
-            </label>
-            <label>Tool
-              <input
-                value={tool}
-                onChange={e => setTool(e.target.value)}
-                placeholder="e.g. GPT-4, Midjourney"
-              />
-            </label>
-            <label>Tags
-              <input
-                value={tags}
-                onChange={e => setTags(e.target.value)}
-                placeholder="e.g. copywriting, design (comma-separated)"
-              />
-            </label>
+            <label>Prompt Text <textarea value={text} onChange={e => setText(e.target.value)} placeholder="Prompt text" required /></label>
+            <label>Tool <input value={tool} onChange={e => setTool(e.target.value)} placeholder="e.g. GPT-4, Midjourney" /></label>
+            <label>Tags <input value={tags} onChange={e => setTags(e.target.value)} placeholder="e.g. copywriting, design (comma-separated)" /></label>
             <button type="submit">{editingPrompt ? 'Update Prompt' : 'Add Prompt'}</button>
-            {editingPrompt && (
-              <button type="button" onClick={handleCancelEdit} style={{ marginLeft: '10px' }}>
-                Cancel Edit
-              </button>
-            )}
+            {editingPrompt && (<button type="button" onClick={handleCancelEdit} style={{ marginLeft: '10px' }}>Cancel Edit</button>)}
           </form>
         </section>
+
         <section className="list-controls">
           <label>
-            <input
-              type="checkbox"
-              checked={showOnlyFavorites}
-              onChange={e => setShowOnlyFavorites(e.target.checked)}
-            />
+            <input type="checkbox" checked={showOnlyFavorites} onChange={e => setShowOnlyFavorites(e.target.checked)} />
             Show Favorites Only
           </label>
+          <div className="sort-controls" style={{ marginLeft: '20px', display: 'inline-block' }}>
+            <label htmlFor="sortCriteria">Sort by: </label>
+            <select id="sortCriteria" value={sortCriteria} onChange={e => setSortCriteria(e.target.value)}>
+              <option value="dateAdded">Date Added</option>
+              <option value="usageCountDesc">Usage Count (Most First)</option>
+              <option value="usageCountAsc">Usage Count (Least First)</option>
+              <option value="lastUsedDesc">Last Used (Newest First)</option>
+              <option value="lastUsedAsc">Last Used (Oldest First)</option>
+            </select>
+          </div>
         </section>
+
         <section className="list">
           <ul id="list">
-            {filteredPromptsByFavorite.map(p => ( // Use the client-side filtered list
+            {processedPrompts.map(p => (
               <li key={p.id}>
                 <div className="prompt-header">
                   <span className="tool">{p.tool}</span>
                   <span className="tags">{p.tags.join(', ')}</span>
-                  <button
-                    onClick={() => toggleFavorite(p.id, p.favorite)}
-                    className={`favorite-btn ${p.favorite ? 'favorited' : ''}`}
-                    title={p.favorite ? 'Unfavorite' : 'Favorite'}
-                  >
-                    {p.favorite ? '★' : '☆'}
-                  </button>
-                  <button
-                    onClick={() => handleEdit(p)}
-                    className="edit-btn"
-                    title="Edit Prompt"
-                    style={{ marginLeft: '5px' }}
-                  >
-                    ✏️ Edit
-                  </button>
-                  <button
-                    onClick={() => handleDeletePrompt(p.id)}
-                    className="delete-btn"
-                    title="Delete Prompt"
-                    style={{ marginLeft: '5px', color: 'red' }}
-                  >
-                    🗑️ Delete
-                  </button>
+                  <button onClick={() => toggleFavorite(p.id, p.favorite)} className={`favorite-btn ${p.favorite ? 'favorited' : ''}`} title={p.favorite ? 'Unfavorite' : 'Favorite'}>{p.favorite ? '★' : '☆'}</button>
+                  <button onClick={() => handleEdit(p)} className="edit-btn" title="Edit Prompt" style={{ marginLeft: '5px' }}>✏️ Edit</button>
+                  <button onClick={() => handleDeletePrompt(p.id)} className="delete-btn" title="Delete Prompt" style={{ marginLeft: '5px', color: 'red' }}>🗑️ Delete</button>
                 </div>
                 <div className="text">{p.text}</div>
+                <div className="prompt-usage">
+                  <span>Usage Count: {p.usageCount || 0}</span>
+                  <span style={{ marginLeft: '10px' }}>Last Used: {formatLastUsed(p.lastUsed)}</span>
+                </div>
+                <button onClick={() => handleLogUsage(p)} className="log-usage-btn" style={{ marginTop: '5px' }}>
+                  📋 Copy & Log Use
+                </button>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
This commit introduces features to track and display prompt usage:

1.  **Backend (`server.js`):**
    *   Prompts now default to `usageCount: 0` and `lastUsed: null` upon creation.
    *   Added a new API endpoint `POST /api/prompts/:id/logusage` which increments the prompt's `usageCount` and updates `lastUsed` to the current timestamp.

2.  **Web UI (`public/app.js`):**
    *   Added a "📋 Copy & Log Use" button to each prompt. Clicking it copies the prompt text to the clipboard and calls the `logusage` endpoint.
    *   `Usage Count` and `Last Used` date (formatted) are now displayed for each prompt.
    *   Added client-side sorting options for "Usage Count (Most/Least First)" and "Last Used (Newest/Oldest First)".
    *   Ensured `usageCount` and `lastUsed` are initialized if missing from older prompts.

3.  **Mobile UI (`mobile/App.js`):**
    *   Added a "📋 Copy & Log Use" button to each prompt, with similar functionality to the web version (copies text using `expo-clipboard` and logs usage).
    *   `Usage Count` and `Last Used` date are displayed.
    *   Added a Picker for sorting by usage count and last used date.
    *   Ensured `usageCount` and `lastUsed` are initialized.

This feature allows you to track how often and when your prompts are utilized, providing insights into your most effective or frequently used prompts.