### PR TITLE
feat: Implement prompt history, tool filter, and export/import

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -53,12 +53,24 @@ function App() {
   const [prompts, setPrompts] = useState([]);
   const [search, setSearch] = useState('');
   const [searchTags, setSearchTags] = useState('');
+  const [searchTool, setSearchTool] = useState(''); // State for the new tool filter
   const [text, setText] = useState('');
   const [tool, setTool] = useState('');
   const [tags, setTags] = useState('');
   const [showOnlyFavorites, setShowOnlyFavorites] = useState(false);
   const [editingPrompt, setEditingPrompt] = useState(null);
   const [sortCriteria, setSortCriteria] = useState('dateAdded'); // New state for sorting
+  const [historyModalOpen, setHistoryModalOpen] = useState(false);
+  const [currentPromptHistory, setCurrentPromptHistory] = useState([]);
+  const [selectedPromptForHistory, setSelectedPromptForHistory] = useState(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [historyError, setHistoryError] = useState(null);
+
+  // State for Import/Export
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const [importMessage, setImportMessage] = useState('');
+
 
   const formatLastUsed = (dateString) => {
     if (!dateString) return "Not used yet";
@@ -71,10 +83,14 @@ function App() {
 
   const loadPrompts = async () => {
     try {
-      let queryString = `q=${encodeURIComponent(search)}`;
+      let queryParams = [`q=${encodeURIComponent(search)}`];
       if (searchTags.trim() !== '') {
-        queryString += `&tag=${encodeURIComponent(searchTags)}`;
+        queryParams.push(`tag=${encodeURIComponent(searchTags)}`);
       }
+      if (searchTool.trim() !== '') { // Add tool to query if it's not empty
+        queryParams.push(`tool=${encodeURIComponent(searchTool)}`);
+      }
+      const queryString = queryParams.join('&');
       const res = await fetch(`/api/prompts/search?${queryString}`);
       if (!res.ok) {
         const errorData = await res.json().catch(() => ({ message: `API error: ${res.status}` }));
@@ -220,6 +236,150 @@ function App() {
     }
   };
 
+  // --- History Functions ---
+  const fetchHistory = async (promptId) => {
+    if (!promptId) return;
+    setHistoryLoading(true);
+    setHistoryError(null);
+    setSelectedPromptForHistory(prompts.find(p => p.id === promptId));
+    try {
+      const res = await fetch(`/api/prompts/${promptId}/history`);
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: `API error: ${res.status}` }));
+        throw new Error(errorData.message || 'Failed to fetch history');
+      }
+      const historyData = await res.json();
+      setCurrentPromptHistory(historyData);
+      setHistoryModalOpen(true);
+    } catch (error) {
+      console.error("Error fetching history:", error);
+      setHistoryError(error.message);
+      // Potentially show an alert or keep the modal closed
+      setHistoryModalOpen(false); 
+    } finally {
+      setHistoryLoading(false);
+    }
+  };
+
+  const handleRevert = async (promptId, versionId) => {
+    if (!window.confirm('Are you sure you want to revert to this version? The current version will be saved to history.')) {
+      return;
+    }
+    try {
+      const res = await fetch(`/api/prompts/${promptId}/revert/${versionId}`, { method: 'POST' });
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ message: 'Failed to revert prompt.' }));
+        throw new Error(errorData.message);
+      }
+      const revertedPrompt = await res.json();
+      // Update the main prompts list
+      setPrompts(prevPrompts =>
+        prevPrompts.map(p => (p.id === revertedPrompt.id ? { ...p, ...revertedPrompt } : p))
+      );
+      // If the reverted prompt was being edited, update the edit form
+      if (editingPrompt && editingPrompt.id === revertedPrompt.id) {
+        setText(revertedPrompt.text);
+        setTool(revertedPrompt.tool);
+        setTags(revertedPrompt.tags.join(', '));
+      }
+      alert('Prompt reverted successfully!');
+      setHistoryModalOpen(false);
+      // Optionally, refresh history for the current prompt if the modal were to stay open
+      // fetchHistory(promptId); 
+    } catch (error) {
+      console.error('Error reverting prompt:', error);
+      alert(`Error reverting prompt: ${error.message}`);
+    }
+  };
+
+
+  // --- Export/Import Functions ---
+  const handleExportPrompts = async () => {
+    try {
+      const response = await fetch('/api/prompts/export');
+      if (!response.ok) {
+        throw new Error(`Export failed: ${response.statusText}`);
+      }
+      // The browser should handle the download automatically due to Content-Disposition
+      // Forcing download via JavaScript:
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.style.display = 'none';
+      a.href = url;
+      a.download = 'prompts_export.json'; // Filename suggestion
+      document.body.appendChild(a);
+      a.click();
+      window.URL.revokeObjectURL(url);
+      a.remove();
+      alert('Prompts exported successfully!');
+    } catch (error) {
+      console.error('Export error:', error);
+      alert(`Export failed: ${error.message}`);
+    }
+  };
+
+  const handleFileChange = (event) => {
+    setSelectedFile(event.target.files[0]);
+    setImportMessage(''); // Clear previous messages
+  };
+
+  const handleImportPrompts = async () => {
+    if (!selectedFile) {
+      setImportMessage('Please select a JSON file to import.');
+      return;
+    }
+    if (selectedFile.type !== "application/json") {
+        setImportMessage('Invalid file type. Please select a JSON file.');
+        return;
+    }
+
+    setIsImporting(true);
+    setImportMessage('Importing prompts...');
+
+    const reader = new FileReader();
+    reader.onload = async (event) => {
+      try {
+        const fileContent = event.target.result;
+        // Validate if content is JSON before sending (optional, backend also validates)
+        JSON.parse(fileContent); 
+
+        const response = await fetch('/api/prompts/import', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: fileContent,
+        });
+
+        const result = await response.json();
+        if (!response.ok) {
+          throw new Error(result.error || `Import failed with status: ${response.status}`);
+        }
+        
+        setImportMessage(`Import successful! ${result.importedCount} prompts imported.`);
+        loadPrompts(); // Refresh the list
+        setSelectedFile(null); // Clear the selected file
+        // Clear the file input visually
+        const fileInput = document.getElementById('importFile');
+        if (fileInput) {
+            fileInput.value = '';
+        }
+      } catch (error) {
+        console.error('Import error:', error);
+        setImportMessage(`Import failed: ${error.message}`);
+      } finally {
+        setIsImporting(false);
+      }
+    };
+    reader.onerror = (error) => {
+        console.error('File reading error:', error);
+        setImportMessage('Error reading file.');
+        setIsImporting(false);
+    };
+    reader.readAsText(selectedFile);
+  };
+
   // --- Sorting and Filtering Logic ---
   let processedPrompts = [...prompts];
 
@@ -263,6 +423,9 @@ function App() {
           <div className="search-tags">
             <input value={searchTags} onChange={e => setSearchTags(e.target.value)} placeholder="Filter by tags (e.g., js, python)" />
           </div>
+          <div className="search-tool"> {/* New input field for tool filter */}
+            <input value={searchTool} onChange={e => setSearchTool(e.target.value)} placeholder="Filter by tool (e.g., GPT-4)" />
+          </div>
           <button onClick={handleExecuteSearch}>Search</button>
         </div>
       </header>
@@ -274,6 +437,93 @@ function App() {
             <label>Prompt Text <textarea value={text} onChange={e => setText(e.target.value)} placeholder="Prompt text" required /></label>
             <label>Tool <input value={tool} onChange={e => setTool(e.target.value)} placeholder="e.g. GPT-4, Midjourney" /></label>
             <label>Tags <input value={tags} onChange={e => setTags(e.target.value)} placeholder="e.g. copywriting, design (comma-separated)" /></label>
+            <button type="submit">{editingPrompt ? 'Update Prompt' : 'Add Prompt'}</button>
+            {editingPrompt && (<button type="button" onClick={handleCancelEdit} style={{ marginLeft: '10px' }}>Cancel Edit</button>)}
+          </form>
+        </section>
+        
+        <section className="data-management">
+          <h2>Data Management</h2>
+          <div className="export-controls">
+            <button onClick={handleExportPrompts}>Export All Prompts</button>
+          </div>
+          <div className="import-controls">
+            <h3>Import Prompts</h3>
+            <input type="file" id="importFile" accept=".json" onChange={handleFileChange} />
+            <button onClick={handleImportPrompts} disabled={!selectedFile || isImporting}>
+              {isImporting ? 'Importing...' : 'Import Selected JSON'}
+            </button>
+            {importMessage && <p className={`import-message ${importMessage.startsWith('Import failed') || importMessage.startsWith('Error') || importMessage.startsWith('Please') ? 'error' : 'success'}`}>{importMessage}</p>}
+          </div>
+        </section>
+
+        <section className="list-controls">
+          <label>
+            <input type="checkbox" checked={showOnlyFavorites} onChange={e => setShowOnlyFavorites(e.target.checked)} />
+            Show Favorites Only
+          </label>
+          <div className="sort-controls" style={{ marginLeft: '20px', display: 'inline-block' }}>
+            <label htmlFor="sortCriteria">Sort by: </label>
+            <select id="sortCriteria" value={sortCriteria} onChange={e => setSortCriteria(e.target.value)}>
+              <option value="dateAdded">Date Added</option>
+              <option value="usageCountDesc">Usage Count (Most First)</option>
+              <option value="usageCountAsc">Usage Count (Least First)</option>
+              <option value="lastUsedDesc">Last Used (Newest First)</option>
+              <option value="lastUsedAsc">Last Used (Oldest First)</option>
+            </select>
+          </div>
+        </section>
+
+        <section className="list">
+          <ul id="list">
+            {processedPrompts.map(p => (
+              <li key={p.id}>
+                <div className="prompt-header">
+                  <span className="tool">{p.tool}</span>
+                  <span className="tags">{p.tags.join(', ')}</span>
+                  <button onClick={() => toggleFavorite(p.id, p.favorite)} className={`favorite-btn ${p.favorite ? 'favorited' : ''}`} title={p.favorite ? 'Unfavorite' : 'Favorite'}>{p.favorite ? '★' : '☆'}</button>
+                  <button onClick={() => handleEdit(p)} className="edit-btn" title="Edit Prompt" style={{ marginLeft: '5px' }}>✏️ Edit</button>
+                  <button onClick={() => fetchHistory(p.id)} className="history-btn" title="View History" style={{ marginLeft: '5px' }} disabled={historyLoading && selectedPromptForHistory?.id === p.id}>📜 History</button>
+                  <button onClick={() => handleDeletePrompt(p.id)} className="delete-btn" title="Delete Prompt" style={{ marginLeft: '5px', color: 'red' }}>🗑️ Delete</button>
+                </div>
+                <div className="text">{p.text}</div>
+                <div className="prompt-usage">
+                  <span>Usage Count: {p.usageCount || 0}</span>
+                  <span style={{ marginLeft: '10px' }}>Last Used: {formatLastUsed(p.lastUsed)}</span>
+                </div>
+                <button onClick={() => handleLogUsage(p)} className="log-usage-btn" style={{ marginTop: '5px' }}>
+                  📋 Copy & Log Use
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+
+  return (
+    <div className="app">
+      {/* Header and Add/Edit Form remain the same */}
+      <header className="header">
+        <h1>PromptCache</h1>
+        <div className="search-controls">
+          <div className="search-keywords">
+            <input value={search} onChange={e => setSearch(e.target.value)} placeholder="Search by keyword..." />
+          </div>
+          <div className="search-tags">
+            <input value={searchTags} onChange={e => setSearchTags(e.target.value)} placeholder="Filter by tags (e.g., js, python)" />
+          </div>
+          <button onClick={handleExecuteSearch}>Search</button>
+        </div>
+      </header>
+      <main>
+        <section className="add">
+          <h2>{editingPrompt ? 'Edit Prompt' : 'Add Prompt'}</h2>
+          <form onSubmit={handleSubmitPrompt} id="newPrompt">
+            <label>Prompt Text <textarea value={text} onChange={e => setText(e.target.value)} placeholder="Prompt text" required /></label>
+            <label>Tool <input value={tool} onChange={e => setTool(e.target.value)} placeholder="e.g. GPT-4, Midjourney" /></label>
+            <label>Tags <input value={tags} onChange={e => setTags(e.value)} placeholder="e.g. copywriting, design (comma-separated)" /></label>
             <button type="submit">{editingPrompt ? 'Update Prompt' : 'Add Prompt'}</button>
             {editingPrompt && (<button type="button" onClick={handleCancelEdit} style={{ marginLeft: '10px' }}>Cancel Edit</button>)}
           </form>
@@ -305,9 +555,10 @@ function App() {
                   <span className="tags">{p.tags.join(', ')}</span>
                   <button onClick={() => toggleFavorite(p.id, p.favorite)} className={`favorite-btn ${p.favorite ? 'favorited' : ''}`} title={p.favorite ? 'Unfavorite' : 'Favorite'}>{p.favorite ? '★' : '☆'}</button>
                   <button onClick={() => handleEdit(p)} className="edit-btn" title="Edit Prompt" style={{ marginLeft: '5px' }}>✏️ Edit</button>
+                  <button onClick={() => fetchHistory(p.id)} className="history-btn" title="View History" style={{ marginLeft: '5px' }} disabled={historyLoading && selectedPromptForHistory?.id === p.id}>📜 History</button>
                   <button onClick={() => handleDeletePrompt(p.id)} className="delete-btn" title="Delete Prompt" style={{ marginLeft: '5px', color: 'red' }}>🗑️ Delete</button>
                 </div>
-                <div className="text">{p.text}</div>
+                <div className="text" style={{ whiteSpace: 'pre-wrap' }}>{p.text}</div>
                 <div className="prompt-usage">
                   <span>Usage Count: {p.usageCount || 0}</span>
                   <span style={{ marginLeft: '10px' }}>Last Used: {formatLastUsed(p.lastUsed)}</span>
@@ -320,9 +571,195 @@ function App() {
           </ul>
         </section>
       </main>
+      {historyModalOpen && selectedPromptForHistory && (
+        <PromptHistoryModal
+          isOpen={historyModalOpen}
+          onClose={() => setHistoryModalOpen(false)}
+          promptTitle={selectedPromptForHistory.text.substring(0, 50) + "..."} // Pass a title or identifier
+          historyData={currentPromptHistory}
+          onRevert={(versionId) => handleRevert(selectedPromptForHistory.id, versionId)}
+          isLoading={historyLoading}
+          error={historyError}
+        />
+      )}
+      <style jsx global>{`
+        .data-management {
+          background-color: #f9f9f9;
+          padding: 15px;
+          margin-bottom: 20px;
+          border-radius: 8px;
+          border: 1px solid #eee;
+        }
+        .data-management h2 {
+          margin-top: 0;
+          margin-bottom: 15px;
+          font-size: 1.2em;
+        }
+        .export-controls, .import-controls {
+          margin-bottom: 15px;
+        }
+        .import-controls h3 {
+          margin-top: 0;
+          margin-bottom: 10px;
+          font-size: 1.1em;
+        }
+        .import-controls input[type="file"] {
+          margin-right: 10px;
+          margin-bottom: 10px; /* Stack on smaller screens */
+        }
+        .import-message {
+          margin-top: 10px;
+          padding: 8px;
+          border-radius: 4px;
+        }
+        .import-message.success {
+          background-color: #e6ffed;
+          border: 1px solid #b7ebc9;
+          color: #2f6f4f;
+        }
+        .import-message.error {
+          background-color: #ffe6e6;
+          border: 1px solid #ffb3b3;
+          color: #990000;
+        }
+      `}</style>
     </div>
   );
 }
 
+function PromptHistoryModal({ isOpen, onClose, promptTitle, historyData, onRevert, isLoading, error }) {
+  if (!isOpen) return null;
+
+  const formatVersionId = (isoString) => {
+    const date = new Date(isoString);
+    return `Saved on ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <div className="modal">
+        <div className="modal-header">
+          <h3>History for: "{promptTitle}"</h3>
+          <button onClick={onClose} className="modal-close-btn">&times;</button>
+        </div>
+        <div className="modal-body">
+          {isLoading && <p>Loading history...</p>}
+          {error && <p className="error-message">Error loading history: {error}</p>}
+          {!isLoading && !error && historyData.length === 0 && <p>No history available for this prompt.</p>}
+          {!isLoading && !error && historyData.length > 0 && (
+            <ul>
+              {historyData.map(entry => (
+                <li key={entry.versionId} className="history-entry">
+                  <div className="history-version-id">{formatVersionId(entry.versionId)}</div>
+                  <div className="history-details">
+                    <p><strong>Text:</strong> <span style={{ whiteSpace: 'pre-wrap', display: 'block', maxHeight: '100px', overflowY: 'auto', border: '1px solid #eee', padding: '5px' }}>{entry.promptData.text}</span></p>
+                    <p><strong>Tool:</strong> {entry.promptData.tool || 'N/A'}</p>
+                    <p><strong>Tags:</strong> {(entry.promptData.tags || []).join(', ') || 'N/A'}</p>
+                  </div>
+                  <button onClick={() => onRevert(entry.versionId)} className="revert-btn">
+                    Revert to this version
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="modal-footer">
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+      {/* Basic styling for modal - should be in CSS file */}
+      <style jsx global>{`
+        .modal-backdrop {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(0, 0, 0, 0.5);
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          z-index: 1000;
+        }
+        .modal {
+          background-color: white;
+          padding: 20px;
+          border-radius: 8px;
+          min-width: 500px;
+          max-width: 80%;
+          max-height: 80vh;
+          display: flex;
+          flex-direction: column;
+          box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+        }
+        .modal-header {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom: 1px solid #eee;
+          padding-bottom: 10px;
+          margin-bottom: 10px;
+        }
+        .modal-header h3 {
+          margin: 0;
+        }
+        .modal-close-btn {
+          background: none;
+          border: none;
+          font-size: 1.5rem;
+          cursor: pointer;
+        }
+        .modal-body {
+          overflow-y: auto;
+          flex-grow: 1;
+        }
+        .modal-footer {
+          border-top: 1px solid #eee;
+          padding-top: 10px;
+          margin-top: 10px;
+          text-align: right;
+        }
+        .history-entry {
+          border-bottom: 1px solid #f0f0f0;
+          padding: 10px 0;
+          margin-bottom: 10px;
+        }
+        .history-entry:last-child {
+          border-bottom: none;
+        }
+        .history-version-id {
+          font-weight: bold;
+          margin-bottom: 5px;
+          color: #333;
+        }
+        .history-details p {
+          margin: 3px 0;
+          font-size: 0.9em;
+        }
+        .history-details strong {
+          color: #555;
+        }
+        .revert-btn {
+          margin-top: 10px;
+          padding: 5px 10px;
+          background-color: #007bff;
+          color: white;
+          border: none;
+          border-radius: 4px;
+          cursor: pointer;
+        }
+        .revert-btn:hover {
+          background-color: #0056b3;
+        }
+        .error-message {
+          color: red;
+          font-weight: bold;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+
 ReactDOM.render(<App />, document.getElementById('root'));
-main

--- a/server.js
+++ b/server.js
@@ -41,7 +41,8 @@ function handleAPI(req, res) {
   if (parsed.pathname === '/api/prompts/search' && req.method === 'GET') {
     const q = (parsed.query.q || '').toLowerCase();
     const tagQuery = parsed.query.tag; // e.g., "tag1,tag2, tag3 "
-    
+    const toolQuery = (parsed.query.tool || '').toLowerCase(); // New tool query parameter
+
     let queryTags = [];
     if (tagQuery && typeof tagQuery === 'string' && tagQuery.trim() !== '') {
       queryTags = tagQuery.split(',')
@@ -60,10 +61,15 @@ function handleAPI(req, res) {
       let tagMatch = true; // Default to true if no tags are specified in the query
       if (queryTags.length > 0) {
         // If there are queryTags, prompt must have at least one of them
-        tagMatch = p.tags.some(promptTag => queryTags.includes(promptTag));
+        // Ensure p.tags exists and is an array before calling .some()
+        tagMatch = Array.isArray(p.tags) && p.tags.some(promptTag => queryTags.includes(promptTag.toLowerCase()));
       }
+
+      // Tool filter (toolQuery parameter)
+      // Ensure p.tool exists before calling toLowerCase()
+      const toolMatch = (toolQuery === '') || (p.tool && p.tool.toLowerCase() === toolQuery);
       
-      return textMatch && tagMatch;
+      return textMatch && tagMatch && toolMatch;
     });
     return send(res, 200, filtered);
   }
@@ -97,16 +103,119 @@ function handleAPI(req, res) {
     let body = '';
     req.on('data', c => body += c);
     req.on('end', () => {
-      const data = JSON.parse(body);
-      const idx = prompts.findIndex(p => p.id === id);
-      if (idx === -1) return send(res, 404, { error: 'Not found' });
-      prompts[idx] = { ...prompts[idx], ...data };
-      save();
-      send(res, 200, prompts[idx]);
+      try {
+        const data = JSON.parse(body);
+        const idx = prompts.findIndex(p => p.id === id);
+        if (idx === -1) return send(res, 404, { error: 'Not found' });
+
+        // Ensure history array exists and is initialized
+        if (!prompts[idx].history) {
+          prompts[idx].history = [];
+        }
+
+        // Save current state to history
+        const currentVersion = { ...prompts[idx] };
+        // Remove history from the version being saved to avoid nested histories
+        delete currentVersion.history; 
+        
+        prompts[idx].history.unshift({ // Add to the beginning of the array
+          versionId: new Date().toISOString(),
+          promptData: currentVersion
+        });
+
+        // Limit history to 10 versions
+        if (prompts[idx].history.length > 10) {
+          prompts[idx].history.pop(); // Remove the oldest version
+        }
+
+        // Update prompt with new data
+        prompts[idx] = { ...prompts[idx], ...data, history: prompts[idx].history }; // Persist history
+
+        save();
+        send(res, 200, prompts[idx]);
+      } catch (err) {
+        send(res, 400, { error: 'Invalid JSON or error during history update' });
+      }
     });
     return;
   }
-7ubkob-codex/improve-ui-design-of-promptcache
+
+  // --- GET /api/prompts/:id/history ---
+  if (parsed.pathname.match(/^\/api\/prompts\/(\d+)\/history$/) && req.method === 'GET') {
+    const idStr = parsed.pathname.split('/')[3];
+    const id = parseInt(idStr);
+
+    if (isNaN(id)) {
+      return send(res, 400, { error: 'Invalid Prompt ID format' });
+    }
+
+    const prompt = prompts.find(p => p.id === id);
+    if (!prompt) {
+      return send(res, 404, { error: 'Prompt not found' });
+    }
+
+    return send(res, 200, prompt.history || []);
+  }
+  
+  // --- POST /api/prompts/:id/revert/:versionId ---
+  if (parsed.pathname.match(/^\/api\/prompts\/(\d+)\/revert\/([^/]+)$/) && req.method === 'POST') {
+    const idStr = parsed.pathname.split('/')[3];
+    const versionId = parsed.pathname.split('/')[5];
+    const id = parseInt(idStr);
+
+    if (isNaN(id)) {
+      return send(res, 400, { error: 'Invalid Prompt ID format' });
+    }
+
+    const promptIndex = prompts.findIndex(p => p.id === id);
+    if (promptIndex === -1) {
+      return send(res, 404, { error: 'Prompt not found' });
+    }
+
+    const prompt = prompts[promptIndex];
+    if (!prompt.history) {
+      return send(res, 404, { error: 'No history found for this prompt' });
+    }
+
+    const historyEntry = prompt.history.find(h => h.versionId === versionId);
+    if (!historyEntry) {
+      return send(res, 404, { error: 'Version not found in history' });
+    }
+
+    // Save current state (before reverting) to history
+    const currentVersionData = { 
+        text: prompt.text, 
+        tool: prompt.tool, 
+        tags: prompt.tags,
+        favorite: prompt.favorite,
+        // Potentially other fields like usageCount, lastUsed should be preserved from the current state,
+        // or explicitly decide if reverting should reset them too.
+        // For now, let's assume we only revert text, tool, tags.
+    };
+
+    prompt.history.unshift({
+      versionId: new Date().toISOString(),
+      promptData: currentVersionData
+    });
+
+    // Limit history
+    if (prompt.history.length > 10) {
+      prompt.history.pop();
+    }
+    
+    // Revert prompt to historical version's data
+    prompt.text = historyEntry.promptData.text;
+    prompt.tool = historyEntry.promptData.tool;
+    prompt.tags = historyEntry.promptData.tags;
+    // Note: We are not reverting 'favorite', 'usageCount', 'lastUsed' status by default.
+    // This can be a design choice. If they need to be reverted, copy them from historyEntry.promptData as well.
+
+    prompts[promptIndex] = prompt; // Update the prompt in the main array
+    save();
+    return send(res, 200, prompt);
+  }
+
+  // --- DELETE /api/prompts/:id ---
   if (parsed.pathname.startsWith('/api/prompts/') && req.method === 'DELETE') {
     const id = parseInt(parsed.pathname.split('/')[3]);
     const idx = prompts.findIndex(p => p.id === id);
@@ -137,6 +246,68 @@ function handleAPI(req, res) {
     save(); // Persist changes to prompts.json
 
     return send(res, 200, { message: 'Prompt deleted successfully' });
+  }
+
+  // --- GET /api/prompts/export ---
+  if (parsed.pathname === '/api/prompts/export' && req.method === 'GET') {
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Disposition': 'attachment; filename="prompts_export.json"'
+    });
+    // Send a stringified version of prompts, but only specific fields
+    // This prevents exporting internal state like history or usageCount if not desired
+    const exportablePrompts = prompts.map(p => ({
+      text: p.text,
+      tool: p.tool,
+      tags: p.tags
+      // We intentionally do not export id, favorite, history, usageCount, lastUsed
+    }));
+    return res.end(JSON.stringify(exportablePrompts, null, 2));
+  }
+
+  // --- POST /api/prompts/import ---
+  if (parsed.pathname === '/api/prompts/import' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const importedData = JSON.parse(body);
+        if (!Array.isArray(importedData)) {
+          return send(res, 400, { error: 'Invalid import format: Data must be an array of prompts.' });
+        }
+
+        let importedCount = 0;
+        for (const importedPrompt of importedData) {
+          if (typeof importedPrompt.text !== 'string' || importedPrompt.text.trim() === '') {
+            // Skip prompts without valid text
+            console.warn('Skipping import of prompt due to missing or empty text:', importedPrompt);
+            continue; 
+          }
+
+          const newPrompt = {
+            id: nextId++,
+            text: importedPrompt.text,
+            tool: typeof importedPrompt.tool === 'string' ? importedPrompt.tool : '',
+            tags: Array.isArray(importedPrompt.tags) ? importedPrompt.tags.filter(tag => typeof tag === 'string') : [],
+            favorite: false,
+            history: [],
+            usageCount: 0,
+            lastUsed: null
+          };
+          prompts.push(newPrompt);
+          importedCount++;
+        }
+
+        if (importedCount > 0) {
+          save();
+        }
+        send(res, 201, { message: `Import successful. ${importedCount} prompts imported.`, importedCount });
+
+      } catch (err) {
+        send(res, 400, { error: 'Invalid JSON payload or error during import.' });
+      }
+    });
+    return;
   }
 
   // --- POST /api/prompts/:id/logusage ---


### PR DESCRIPTION
This commit introduces three major features to the PromptCache application:

1.  **Prompt History/Versioning:**
    - Backend: Prompts now store a history of their last 10 versions upon update. New API endpoints allow fetching history and reverting to a version.
    - Frontend: You can view a prompt's history and revert to a previous version via a modal interface.

2.  **Enhanced Search - Filter by Tool:**
    - Backend: The search API now supports filtering by a `tool` query parameter, in addition to keywords and tags. Tag search is now case-insensitive.
    - Frontend: A new input field allows you to filter prompts by tool.

3.  **Export/Import Prompts:**
    - Backend: New API endpoints enable exporting all prompts to JSON and importing prompts from a JSON file. Import assigns new IDs and defaults.
    - Frontend: You can now export all your prompts and import prompts from a previously exported JSON file.

These features enhance prompt management, search capabilities, and data portability for the web application.